### PR TITLE
feat: add dark mode and scroll to top

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -140,3 +140,31 @@ footer a:not(.nav-link) {
   .page-break {
     padding-top: 5rem;
     page-break-before: always; } }
+
+#floating-buttons {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 1000; }
+
+#scroll-top-btn {
+  display: none; }
+
+body.dark-mode {
+  background-color: #121212;
+  color: #f1f1f1; }
+
+body.dark-mode .bg-white {
+  background-color: #1e1e1e !important; }
+
+body.dark-mode .text-muted {
+  color: #bbbbbb !important; }
+
+body.dark-mode a {
+  color: #66b2ff; }
+
+body.dark-mode .nav-link {
+  color: #f1f1f1; }

--- a/static/scripts/main.js
+++ b/static/scripts/main.js
@@ -5,3 +5,33 @@ AOS.init({
 });
 
 // Add your javascript here
+
+const scrollBtn = document.getElementById('scroll-top-btn');
+const themeToggle = document.getElementById('theme-toggle');
+
+if (scrollBtn) {
+  window.addEventListener('scroll', () => {
+    if (window.pageYOffset > 100) {
+      scrollBtn.style.display = 'block';
+    } else {
+      scrollBtn.style.display = 'none';
+    }
+  });
+  scrollBtn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+}
+
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const icon = themeToggle.querySelector('i');
+    if (document.body.classList.contains('dark-mode')) {
+      icon.classList.remove('fa-moon');
+      icon.classList.add('fa-sun');
+    } else {
+      icon.classList.remove('fa-sun');
+      icon.classList.add('fa-moon');
+    }
+  });
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -344,6 +344,10 @@
         </div>
       </div>
     </footer>
+    <div id="floating-buttons" class="d-print-none">
+      <button id="scroll-top-btn" class="btn btn-info btn-sm mb-2"><i class="fas fa-arrow-up"></i></button>
+      <button id="theme-toggle" class="btn btn-secondary btn-sm"><i class="fas fa-moon"></i></button>
+    </div>
     <script src="/static/scripts/mdb.min.js?ver=1.2.1"></script>
     <script src="/static/scripts/aos.js?ver=1.2.1"></script>
     <script src="/static/scripts/main.js?ver=1.2.1"></script>


### PR DESCRIPTION
## Summary
- add floating button container with scroll-to-top and theme toggle controls
- style floating buttons and implement dark mode appearance
- add JavaScript handlers for dark mode and scroll-to-top

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68959019f26c8329a1fa87ae8a1973aa